### PR TITLE
Add support for TypeScript enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## SNAPSHOT - 2023-01-03
+
+Support for TypeScript enums, which previously failed the `no-unused-vars` rule.
+
 ## v5.0.0 - 2022-11-21
 
 Support for TypeScript, including switch to specify `parser: "@typescript-eslint/parser"` and minor modifications to

--- a/index.js
+++ b/index.js
@@ -82,7 +82,8 @@ module.exports = {
         'react-hooks/rules-of-hooks': 'off',
 
         // Hoist - enabled / customized
-        'no-unused-vars': ['error', {
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': ['error', {
             ignoreRestSiblings: true,
             args: 'none'
         }],


### PR DESCRIPTION
Discovered that TS enums fail our base eslint configuration's `[no-unused-vars]` rule.

I found this GH issue: https://github.com/typescript-eslint/typescript-eslint/issues/2621

The workaround it suggests is to update the rules like this:
```
rules: {
  "no-unused-vars": "off",
  "@typescript-eslint/no-unused-vars": "error"
}
```
I confirmed this works by updating `.eslintrc` at app-level.