### PR TITLE
Use '@typescript-eslint/no-unused-vars'

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = {
         'react-hooks/rules-of-hooks': 'off',
 
         // Hoist - enabled / customized
-        'no-unused-vars': ['error', {
+        '@typescript-eslint/no-unused-vars': ['error', {
             ignoreRestSiblings: true,
             args: 'none'
         }],


### PR DESCRIPTION
https://typescript-eslint.io/rules/no-unused-vars/

We were using the old, non-typescript version of this method, which caused it to https://github.com/typescript-eslint/typescript-eslint/issues/1197.

This motivated me to notice we are currently using the eslint recommended (`extends: ['eslint:recommended']`).
Do we explicitly NOT want the typescript-eslint recommended `extends: ['plugin:@typescript-eslint/recommended']`?

https://typescript-eslint.io/linting/configs/#recommended